### PR TITLE
Renamed base --> mat-process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ jobs:
       - setup_remote_docker
       - run:
           name: build
-          command: docker-compose build base-api-test
+          command: docker-compose build mat-process-api-test
       - run:
           name: Run tests
-          command: docker-compose up base-api-test
+          command: docker-compose up mat-process-api-test
 
 workflows:
   check-and-deploy:

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,16 @@ setup:
 
 .PHONY: build
 build:
-	docker-compose run base-api dotnet build
+	docker-compose run mat-process-api dotnet build
 
 .PHONY: serve
 serve:
-	docker-compose up base-api
+	docker-compose up mat-process-api
 
 .PHONY: shell
 shell:
-	docker-compose run base-api bash
+	docker-compose run mat-process-api bash
 
 .PHONY: test
 test:
-	docker-compose build base-api-test && docker-compose up base-api-test
+	docker-compose build mat-process-api-test && docker-compose up mat-process-api-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 version: '3.2'
 
 services:
-  base-api:
-    image: base-api
+  mat-process-api:
+    image: mat-process-api
     build:
-      context: base-api/
+      context: mat-process-api/
       dockerfile: ./Dockerfile
     ports:
       - 3000:3000
 
-  base-api-test:
-    image: base-api-test
+  mat-process-api-test:
+    image: mat-process-api-test
     build:
       context: .
-      dockerfile: base-api.Tests/Dockerfile
+      dockerfile: mat-process-api.Tests/Dockerfile

--- a/mat-process-api.Tests/Dockerfile
+++ b/mat-process-api.Tests/Dockerfile
@@ -6,16 +6,16 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
-COPY ./base-api.sln ./
-COPY ./base-api/base-api.csproj ./base-api/
-COPY ./base-api.Tests/base-api.Tests.csproj ./base-api.Tests/
+COPY ./mat-process-api.sln ./
+COPY ./mat-process-api/mat-process-api.csproj ./mat-process-api/
+COPY ./mat-process-api.Tests/mat-process-api.Tests.csproj ./mat-process-api.Tests/
 
-RUN dotnet restore ./base-api/base-api.csproj
-RUN dotnet restore ./base-api.Tests/base-api.Tests.csproj
+RUN dotnet restore ./mat-process-api/mat-process-api.csproj
+RUN dotnet restore ./mat-process-api.Tests/mat-process-api.Tests.csproj
 
 # Copy everything else and build
 COPY . .
 
-RUN dotnet build -c debug -o out base-api.Tests/base-api.Tests.csproj
+RUN dotnet build -c debug -o out mat-process-api.Tests/mat-process-api.Tests.csproj
 
 CMD dotnet test

--- a/mat-process-api/Dockerfile
+++ b/mat-process-api/Dockerfile
@@ -26,4 +26,4 @@ WORKDIR /app
 COPY --from=builder /app/out .
 
 EXPOSE ${PORT:-3000}
-CMD ASPNETCORE_URLS=http://+:${PORT:-3000} dotnet ./base-api.dll
+CMD ASPNETCORE_URLS=http://+:${PORT:-3000} dotnet ./mat-process-api.dll


### PR DESCRIPTION
What:
 - Renaming the templete name into project name within template's infrastructure files (Dockerfiles and CircleCI config)

Why:
 - Naming consistency within the code.
 - Because we don't have template parameterized. Not sure if that's even possible.

Notes:
 - Not really part of any Jira Ticket on the board right now. However this is required setup of the APIs repository.