### PR TITLE
Fixing CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: docker-compose build mat-process-api-test
       - run:
           name: Run tests
-          command: docker-compose up mat-process-api-test
+          command: docker-compose run mat-process-api-test
 
 workflows:
   check-and-deploy:


### PR DESCRIPTION
What:
 - Fix that stops CI pipeline from pretending to be fine, when the tests are actually failing.

Why:
 - Because even though the tests might pass locally, we need to make sure we know if they don't pass on a different environment.
 - Without it CI pipeline is close to useless.

Notes:
 - These tests are supposed to be failing, because in the code it's referencing a stub db, we won't use, and that we have omited from infrastructure configuration for this project.