### PR TITLE
MT3-273 #ready-for-test #comment Mock Update endpoint implemented

### DIFF
--- a/mat-process-api.Tests/V1/Controllers/ProcessDataControllerTests.cs
+++ b/mat-process-api.Tests/V1/Controllers/ProcessDataControllerTests.cs
@@ -68,5 +68,20 @@ namespace mat_process_api.Tests.V1.Controllers
             //assert
             _mockUsecase.Verify(x => x.ExecuteGet((It.Is<GetProcessDataRequest>(i => i.processRef == processRef))));
         }
+
+        [Test]
+        public void when_updateexistingprocessdocument_method_is_called_then_it_returns_a_success_response()
+        {
+            //arrange
+            int expectedStatusCode = 204; //status code not yet decided, so I go with the one that does not require content body
+            //act
+            IActionResult controllerResponse = _processDataController.UpdateExistingProcessDocument();
+            NoContentResult noContentResult = (NoContentResult)controllerResponse;
+            var actualStatusCode = noContentResult.StatusCode;
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(noContentResult);
+            Assert.AreEqual(expectedStatusCode, actualStatusCode);
+        }
     }
 }

--- a/mat-process-api.Tests/V1/Controllers/ProcessDataControllerTests.cs
+++ b/mat-process-api.Tests/V1/Controllers/ProcessDataControllerTests.cs
@@ -73,14 +73,14 @@ namespace mat_process_api.Tests.V1.Controllers
         public void when_updateexistingprocessdocument_method_is_called_then_it_returns_a_success_response()
         {
             //arrange
-            int expectedStatusCode = 204; //status code not yet decided, so I go with the one that does not require content body
+            int expectedStatusCode = 200; //status code not yet decided, so I go with the one that does not require content body
             //act
             IActionResult controllerResponse = _processDataController.UpdateExistingProcessDocument();
-            NoContentResult noContentResult = (NoContentResult)controllerResponse;
-            var actualStatusCode = noContentResult.StatusCode;
+            OkResult okResult = (OkResult)controllerResponse;
+            int actualStatusCode = okResult.StatusCode;
             //assert
             Assert.NotNull(controllerResponse);
-            Assert.NotNull(noContentResult);
+            Assert.NotNull(okResult);
             Assert.AreEqual(expectedStatusCode, actualStatusCode);
         }
     }

--- a/mat-process-api.Tests/V1/Controllers/ProcessDataControllerTests.cs
+++ b/mat-process-api.Tests/V1/Controllers/ProcessDataControllerTests.cs
@@ -73,7 +73,7 @@ namespace mat_process_api.Tests.V1.Controllers
         public void when_updateexistingprocessdocument_method_is_called_then_it_returns_a_success_response()
         {
             //arrange
-            int expectedStatusCode = 200; //status code not yet decided, so I go with the one that does not require content body
+            int expectedStatusCode = 200; //status code not yet decided, so I go with the 200 for now
             //act
             IActionResult controllerResponse = _processDataController.UpdateExistingProcessDocument();
             OkResult okResult = (OkResult)controllerResponse;

--- a/mat-process-api/V1/Controllers/ProcessDataController.cs
+++ b/mat-process-api/V1/Controllers/ProcessDataController.cs
@@ -47,16 +47,17 @@ namespace mat_process_api.V1.Controllers
 
         /// <summary>
         /// Updates proccess object JSON document by updating its "processData" property.
-        /// The shape of the response has not been decided on yet, for the time being it's just a "204 No Content" (which is one of the options).
+        /// If processData needs to be update, it's instead replaced with a full new one.
+        /// Returning flat out 200 on successful update
         /// </summary>
         /// <param name="processDataJSON"></param>
         /// <returns></returns>
-        [HttpPut] //This is set as PUT, however I feel it should be PATCH, but it's up for discussion later.
+        [HttpPatch]
         [Produces("application/json")]
-        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public IActionResult UpdateExistingProcessDocument()
         {
-            return NoContent();
+            return Ok();
         }
     }
 }

--- a/mat-process-api/V1/Controllers/ProcessDataController.cs
+++ b/mat-process-api/V1/Controllers/ProcessDataController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using mat_process_api.V1.Boundary;
 using mat_process_api.V1.Domain;
 using mat_process_api.V1.UseCase;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -42,6 +43,20 @@ namespace mat_process_api.V1.Controllers
             var request = new GetProcessDataRequest() {processRef = propertyReference };
             var result = _processDataUsecase.ExecuteGet(request);
             return Ok(result);
+        }
+
+        /// <summary>
+        /// Updates proccess object JSON document by updating its "processData" property.
+        /// The shape of the response has not been decided on yet, for the time being it's just a "204 No Content" (which is one of the options).
+        /// </summary>
+        /// <param name="processDataJSON"></param>
+        /// <returns></returns>
+        [HttpPut] //This is set as PUT, however I feel it should be PATCH, but it's up for discussion later.
+        [Produces("application/json")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public IActionResult UpdateExistingProcessDocument()
+        {
+            return NoContent();
         }
     }
 }


### PR DESCRIPTION
# What:
- A mock "Create Document" PATCH endpoint that only returns an empty 200 Ok.

# Why:
- The "200 Ok" was selected as a response, because the API Swagger documentation did not cover the success cases, and the half the team was not present to discuss what it should be. The status code might change as the work on actual implementation will start off.
- The API Swagger documentation specified that this endpoint should be PUT. However, I believe it contradicts our [API Playbook](https://github.com/LBHackney-IT/API-Playbook/blob/master/api-guidelines/http.md#put) in regard of that PUT should only be used to update whole resource. For partial update like we would need (updating just the 'processData' property out of whole JSON object), we should use PATCH as specified in the [API Playbook](https://github.com/LBHackney-IT/API-Playbook/blob/master/api-guidelines/http.md#patch).

# Notes:
- As with previous endpoint, the question about the status codes remains open. The choices are "200 Ok" if we want to return updated content back, or "204 No Content" if we don't.
- There might a merge conflict with the POST Mock endpoint PR due to parallel branching.
- Jira Ticket [MT3-273]