### PR TITLE
Changed ">" to "|" to fix an issue where multiple commands get combined into a single line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,9 +109,9 @@ jobs:
           command: docker ps
       - run:
           name: authorize docker to access aws ecr
-          command: >
+          command: |
             # aws ecr get-login returns a login command w/ a temp token
-            LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region
+            LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region \
             $<<parameters.region>> --profile default) # default default default default default default default 
             # save it to an env var & use that env var to login
             $LOGIN_COMMAND


### PR DESCRIPTION
# What:
- A change of ">" operator to "|" (used for multiple line commands)

# Why:
- So that pipeline wouldn't break when copy-paste'ing it due to some hidden formatting that trims down the newlines.
- More consistent with what we've been using before for multi-line commands.
- The 'ecr-login' command of the current version of pipeline on this branch is currently not functional due to unexpected ">" behaviour.

# Notes:
- Apparently ">" combines anything together that's separated with only 1 newline (no empty line in between), so you have to add empty lines in between the comments and commands for them not to be appended to the 1st line which is the comment.
# 
![image](https://user-images.githubusercontent.com/43747286/70923922-9b9cac80-2020-11ea-9fc3-e989c8610b45.png)
# 
![image](https://user-images.githubusercontent.com/43747286/70923954-ab1bf580-2020-11ea-8760-8b16961a28ca.png)
# 

- Using the "|" which will interpret every newline as a different command. To use this I also had to add the "\" to that big command between the comments, otherwise it would be interpreted as 2 commands and crash, rather than 1 command across 2 lines. This is also better in the case where copying, pasting removes any successive newlines after the 1st one, which would trip the whole command when ">" is used.

- Based on the circleci workflow that ran on this branch for this commit, it's not visible that the issue got fixed, however. The changes made in the [commit contained within this PR](https://github.com/LBHackney-IT/mat-process-api/commit/9e5c0a49201c418974838f18d4a4b1ee5900054a) are identical to [the one](https://github.com/LBHackney-IT/mat-process-api/commit/0a57ce3cec7ba40fefa11df08ec24c300a136891) of the test branch, where it was demonstrated that this fixes the issue: 

![image](https://user-images.githubusercontent.com/43747286/70925441-22eb1f80-2023-11ea-932e-6456a9d5f461.png)
