### PR TITLE
Feature/image persistence post endpoint

### DIFF
--- a/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
+++ b/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
@@ -1,0 +1,80 @@
+using mat_process_api.V1.Boundary;
+using mat_process_api.V1.Controllers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using System.Threading.Tasks;
+using mat_process_api.V1.UseCase;
+using Bogus;
+using Microsoft.AspNetCore.Mvc;
+
+namespace mat_process_api.Tests.V1.Controllers
+{
+    [TestFixture]
+    public class ProcessDataImagesControllerTests
+    {
+        private ProcessImageController _processImageController;
+        private Mock<IProcessImageUseCase> _mockUsecase;
+        private Faker _faker = new Faker();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockUsecase = new Mock<IProcessImageUseCase>();
+            _processImageController = new ProcessImageController(_mockUsecase.Object);
+        }
+
+        [Test]
+        public void given_valid_request_when_postProcessImage_controller_method_is_called_then_usecase_is_called()
+        {
+            //arrange
+            var request = new PostProcessImageRequest();
+
+            //act
+            _processImageController.PostProcessImage(request);
+
+            //assert
+            _mockUsecase.Verify(u => u.ExecutePost(It.IsAny<PostProcessImageRequest>()), Times.Once);
+        }
+
+        [Test]
+        public void given_valid_request_when_postProcessImage_controller_method_is_called_then_usecase_is_called_with_correct_data()
+        {
+            //arange
+            var request = new PostProcessImageRequest()
+            {
+                processRef = _faker.Random.Guid().ToString(),
+                imageId = _faker.Random.Guid().ToString(),
+                base64Image = _faker.Random.Guid().ToString()
+            };
+
+            //act
+            _processImageController.PostProcessImage(request);
+
+            //assert
+            _mockUsecase.Verify(u => u.ExecutePost(It.Is<PostProcessImageRequest>(obj =>
+                obj.processRef == request.processRef &&
+                obj.imageId == request.imageId &&
+                obj.base64Image == request.base64Image
+                )), Times.Once);
+        }
+
+        [Test]
+        public void given_valid_request_when_postProcessImage_controller_method_is_called_then_it_returns_204_NoContent_result()
+        {
+            //arrange
+            var expectedStatusCode = 204;
+            var request = new PostProcessImageRequest();
+
+            //act
+            var controllerResponse = _processImageController.PostProcessImage(request);
+            var result = (StatusCodeResult)controllerResponse; //not 'ObjectResult' because there's no object contained in this response
+
+            //assert
+            Assert.IsInstanceOf<NoContentResult>(result);
+            Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+    }
+}

--- a/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
+++ b/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using mat_process_api.V1.UseCase;
 using Bogus;
 using Microsoft.AspNetCore.Mvc;
+using mat_process_api.V1.Validators;
 
 namespace mat_process_api.Tests.V1.Controllers
 {
@@ -17,13 +18,15 @@ namespace mat_process_api.Tests.V1.Controllers
     {
         private ProcessImageController _processImageController;
         private Mock<IProcessImageUseCase> _mockUsecase;
+        private Mock<IPostProcessImageRequestValidator> _mockPostValidator;
         private Faker _faker = new Faker();
 
         [SetUp]
         public void SetUp()
         {
             _mockUsecase = new Mock<IProcessImageUseCase>();
-            _processImageController = new ProcessImageController(_mockUsecase.Object);
+            _mockPostValidator = new Mock<IPostProcessImageRequestValidator>();
+            _processImageController = new ProcessImageController(_mockUsecase.Object, _mockPostValidator.Object);
         }
 
         [Test]
@@ -75,6 +78,19 @@ namespace mat_process_api.Tests.V1.Controllers
             //assert
             Assert.IsInstanceOf<NoContentResult>(result);
             Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+
+        [Test]
+        public void given_any_request_when_postProcessImage_controller_method_is_called_then_it_calls_the_validator_with_that_request_object()
+        {
+            //arrange
+            var request = new PostProcessImageRequest();
+
+            //act
+            _processImageController.PostProcessImage(request);
+
+            //assert
+            _mockPostValidator.Verify(v => v.Validate(It.Is<PostProcessImageRequest>(obj => obj == request)), Times.Once);
         }
     }
 }

--- a/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
+++ b/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
@@ -10,6 +10,7 @@ using mat_process_api.V1.UseCase;
 using Bogus;
 using Microsoft.AspNetCore.Mvc;
 using mat_process_api.V1.Validators;
+using mat_process_api.Tests.V1.Helper;
 
 namespace mat_process_api.Tests.V1.Controllers
 {
@@ -46,12 +47,7 @@ namespace mat_process_api.Tests.V1.Controllers
         public void given_valid_request_when_postProcessImage_controller_method_is_called_then_usecase_is_called_with_correct_data()
         {
             //arange
-            var request = new PostProcessImageRequest()
-            {
-                processRef = _faker.Random.Guid().ToString(),
-                imageId = _faker.Random.Guid().ToString(),
-                base64Image = _faker.Random.Guid().ToString()
-            };
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
 
             //act
             _processImageController.PostProcessImage(request);

--- a/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
+++ b/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
@@ -11,6 +11,10 @@ using Bogus;
 using Microsoft.AspNetCore.Mvc;
 using mat_process_api.V1.Validators;
 using mat_process_api.Tests.V1.Helper;
+using FluentValidation.Results;
+using FV = FluentValidation.Results;
+using Newtonsoft.Json;
+
 
 namespace mat_process_api.Tests.V1.Controllers
 {
@@ -30,11 +34,14 @@ namespace mat_process_api.Tests.V1.Controllers
             _processImageController = new ProcessImageController(_mockUsecase.Object, _mockPostValidator.Object);
         }
 
+        #region Post Process Image
+
         [Test]
         public void given_valid_request_when_postProcessImage_controller_method_is_called_then_usecase_is_called()
         {
             //arrange
             var request = new PostProcessImageRequest();
+            _mockPostValidator.Setup(x => x.Validate(request)).Returns(new FV.ValidationResult()); //setup validator to return a no error validation result
 
             //act
             _processImageController.PostProcessImage(request);
@@ -48,6 +55,7 @@ namespace mat_process_api.Tests.V1.Controllers
         {
             //arange
             var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            _mockPostValidator.Setup(x => x.Validate(request)).Returns(new FV.ValidationResult()); //setup validator to return a no error validation result
 
             //act
             _processImageController.PostProcessImage(request);
@@ -66,6 +74,7 @@ namespace mat_process_api.Tests.V1.Controllers
             //arrange
             var expectedStatusCode = 204;
             var request = new PostProcessImageRequest();
+            _mockPostValidator.Setup(x => x.Validate(request)).Returns(new FV.ValidationResult()); //setup validator to return a no error validation result
 
             //act
             var controllerResponse = _processImageController.PostProcessImage(request);
@@ -81,6 +90,7 @@ namespace mat_process_api.Tests.V1.Controllers
         {
             //arrange
             var request = new PostProcessImageRequest();
+            _mockPostValidator.Setup(x => x.Validate(request)).Returns(new FV.ValidationResult()); //setup validator to return a no error validation result
 
             //act
             _processImageController.PostProcessImage(request);
@@ -88,5 +98,64 @@ namespace mat_process_api.Tests.V1.Controllers
             //assert
             _mockPostValidator.Verify(v => v.Validate(It.Is<PostProcessImageRequest>(obj => obj == request)), Times.Once);
         }
+
+        [Test]
+        public void given_an_invalid_request_when_postProcessImage_controller_method_is_called_then_it_returns_400_BadRequest_result()
+        {
+            //arrange
+            var expectedStatusCode = 400;
+            var request = new PostProcessImageRequest(); //an empty request will be invalid
+
+            int errorCount = _faker.Random.Int(1, 10); //simulate from 1 to 10 validation errors (triangulation).
+            var validationErrorList = new List<ValidationFailure>(); //this list will be used as constructor argument for 'ValidationResult'.
+            for (int i = errorCount; i > 0; i--) { validationErrorList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); } //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+
+            var fakeValidationResult = new FV.ValidationResult(validationErrorList); //Need to create ValidationResult so that I could setup Validator mock to return it upon '.Validate()' call. Also this is the only place where it's possible to manipulate the validation result - You can only make the validation result invalid by inserting a list of validation errors as a parameter through a constructor. The boolean '.IsValid' comes from expression 'IsValid => Errors.Count == 0;', so it can't be set manually.
+            _mockPostValidator.Setup(v => v.Validate(It.IsAny<PostProcessImageRequest>())).Returns(fakeValidationResult);
+
+            //act
+            var controllerResponse = _processImageController.PostProcessImage(request);
+            var result = controllerResponse as ObjectResult;
+
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(result);
+            Assert.IsInstanceOf<BadRequestObjectResult>(result);
+            Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+
+        [Test]
+        public void given_an_invalid_request_when_postProcessImage_controller_method_is_called_then_the_response_BadRequest_result_contains_correct_error_messages()
+        {
+            //arrange
+            var expectedStatusCode = 400;
+            var request = new PostProcessImageRequest(); //an empty request will be invalid
+
+            int errorCount = _faker.Random.Int(1, 10); //simulate from 1 to 10 validation errors (triangulation).
+            var validationErrorList = new List<ValidationFailure>(); //this list will be used as constructor argument for 'ValidationResult'.
+            for (int i = errorCount; i > 0; i--) { validationErrorList.Add(new ValidationFailure(_faker.Random.Word(), _faker.Random.Word())); } //generate from 1 to 10 fake validation errors. Single line for-loop so that it wouldn't distract from what's key in this test.
+
+            var fakeValidationResult = new FV.ValidationResult(validationErrorList); //Need to create ValidationResult so that I could setup Validator mock to return it upon '.Validate()' call. Also this is the only place where it's possible to manipulate the validation result - You can only make the validation result invalid by inserting a list of validation errors as a parameter through a constructor. The boolean '.IsValid' comes from expression 'IsValid => Errors.Count == 0;', so it can't be set manually.
+            _mockPostValidator.Setup(v => v.Validate(It.IsAny<PostProcessImageRequest>())).Returns(fakeValidationResult);
+
+            var expectedControllerResponse = new BadRequestObjectResult(validationErrorList); // build up expected controller response to check if the contents of the errors match - that's probably the easiest way to check that.
+
+            //act
+            var controllerResponse = _processImageController.PostProcessImage(request);
+            var result = controllerResponse as ObjectResult;
+            var resultContents = (IList<ValidationFailure>)result.Value;
+
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(result);
+            Assert.IsInstanceOf<BadRequestObjectResult>(result);
+
+            Assert.IsInstanceOf<IList<ValidationFailure>>(resultContents);
+            Assert.NotNull(resultContents);
+            Assert.AreEqual(errorCount, resultContents.Count); // there should be 1 validation failure coming from the invalid guid
+            Assert.AreEqual(JsonConvert.SerializeObject(expectedControllerResponse), JsonConvert.SerializeObject(controllerResponse)); //expectedControllerResponse
+        }
+
+        #endregion
     }
 }

--- a/mat-process-api.Tests/V1/Domain/ProcessImageDataTests.cs
+++ b/mat-process-api.Tests/V1/Domain/ProcessImageDataTests.cs
@@ -1,0 +1,92 @@
+using mat_process_api.V1.Domain;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace mat_process_api.Tests.V1.Domain
+{
+    [TestFixture]
+    public class ProcessImageDataTests
+    {
+        private ProcessImageData _processImageData;
+        private Base64DecodedData _base64DecodedData;
+
+        [SetUp]
+        public void SetUp()
+        {
+            //act
+            _processImageData = new ProcessImageData();
+            _base64DecodedData = new Base64DecodedData();
+        }
+
+        #region ProcessImageData
+
+        [Test]
+        public void when_a_new_ProcessImageData_domain_object_is_created_its_processRef_property_value_defaults_to_null()
+        {
+            //arrange
+            string expectedDefaultValue = null;
+
+            //assert
+            Assert.AreEqual(expectedDefaultValue, _processImageData.processRef);
+        }
+
+        [Test]
+        public void when_a_new_ProcessImageData_domain_object_is_created_its_imageId_property_value_defaults_to_null()
+        {
+            //arrange
+            string expectedDefaultValue = null;
+
+            //assert
+            Assert.AreEqual(expectedDefaultValue, _processImageData.imageId);
+        }
+
+        [Test]
+        public void when_a_new_ProcessImageData_domain_object_is_created_its_imageData_child_object_property_value_defaults_to_null()
+        {
+            //arrange
+            string expectedDefaultValue = null;
+
+            //assert
+            Assert.AreEqual(expectedDefaultValue, _processImageData.imageData);
+        }
+
+        #endregion
+
+        #region Base64DecodedData
+
+        [Test]
+        public void when_a_new_Base64DecodedData_domain_sub_object_is_created_its_imageBytes_property_value_defaults_to_null()
+        {
+            //arrange
+            string expectedDefaultValue = null;
+
+            //assert
+            Assert.AreEqual(expectedDefaultValue, _base64DecodedData.imageBytes);
+        }
+
+        [Test]
+        public void when_a_new_Base64DecodedData_domain_sub_object_is_created_its_imageType_property_value_defaults_to_null()
+        {
+            //arrange
+            string expectedDefaultValue = null;
+
+            //assert
+            Assert.AreEqual(expectedDefaultValue, _base64DecodedData.imageType);
+        }
+
+        [Test]
+        public void when_a_new_Base64DecodedData_domain_sub_object_is_created_its_imageExtension_property_value_defaults_to_null()
+        {
+            //arrange
+            string expectedDefaultValue = null;
+
+            //assert
+            Assert.AreEqual(expectedDefaultValue, _base64DecodedData.imageExtension);
+        }
+
+        #endregion
+    }
+}

--- a/mat-process-api.Tests/V1/Factories/ImageDataFactoryTests.cs
+++ b/mat-process-api.Tests/V1/Factories/ImageDataFactoryTests.cs
@@ -1,0 +1,32 @@
+using mat_process_api.Tests.V1.Helper;
+using mat_process_api.V1.Factories;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace mat_process_api.Tests.V1.Factories
+{
+    [TestFixture]
+    public class ImageDataFactoryTests
+    {
+        [Test]
+        public void given_a_request_and_decodedBase64Data_objects_when_CreateImageDataObject_factory_method_is_called_then_it_outputs_correctly_populated_ProcessImageData_object()
+        {
+            //arrange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            var decodedData = MatProcessDataHelper.CreateBase64DecodedDataObject();
+
+            //act
+            var processImageData = ImageDataFactory.CreateImageDataObject(request, decodedData);
+
+            //asssert
+            Assert.AreEqual(request.processRef, processImageData.processRef);
+            Assert.AreEqual(request.imageId, processImageData.imageId);
+            Assert.AreEqual(decodedData.imageType, processImageData.imageData.imageType);
+            Assert.AreEqual(decodedData.imageExtension, processImageData.imageData.imageExtension);
+            Assert.True(decodedData.imageBytes.SequenceEqual(processImageData.imageData.imageBytes));
+        }
+    }
+}

--- a/mat-process-api.Tests/V1/Helper/MatProcessDataHelper.cs
+++ b/mat-process-api.Tests/V1/Helper/MatProcessDataHelper.cs
@@ -59,5 +59,17 @@ namespace mat_process_api.Tests.V1.Helper
                 base64Image = "data:image/" + faker.System.FileExt() + ";base64," + Convert.ToBase64String(faker.Random.Bytes(512))
             };
         }
+
+        public static Base64DecodedData CreateBase64DecodedDataObject()
+        {
+            var fileExt = faker.System.FileExt();
+
+            return new Base64DecodedData()
+            {
+                imageBytes = faker.Random.Bytes(512),
+                imageType = faker.System.FileType() + "/" + fileExt,
+                imageExtension = fileExt
+            };
+        }
     }
 }

--- a/mat-process-api.Tests/V1/Helper/MatProcessDataHelper.cs
+++ b/mat-process-api.Tests/V1/Helper/MatProcessDataHelper.cs
@@ -12,10 +12,10 @@ namespace mat_process_api.Tests.V1.Helper
 {
     public class MatProcessDataHelper
     {
+        private static Faker faker = new Faker();
+
         public static MatProcessData CreateProcessDataObject()
         {
-            Faker faker = new Faker();
-
             return new MatProcessData
             {
                 Id = faker.Random.Guid().ToString(),
@@ -39,8 +39,6 @@ namespace mat_process_api.Tests.V1.Helper
 
         public static PostInitialProcessDocumentRequest CreatePostInitialProcessDocumentRequestObject()
         {
-            Faker faker = new Faker();
-
             string processRef = faker.Random.Guid().ToString();
             ProcessType processType = new ProcessType()
             {
@@ -50,6 +48,16 @@ namespace mat_process_api.Tests.V1.Helper
             int processDataSchemaVersion = faker.Random.Int();
 
             return new PostInitialProcessDocumentRequest() { processRef = processRef, processType = processType, processDataSchemaVersion = processDataSchemaVersion };
+        }
+
+        public static PostProcessImageRequest CreatePostProcessImageRequestObject()
+        {
+            return new PostProcessImageRequest()
+            {
+                processRef = faker.Random.Guid().ToString(),
+                imageId = faker.Random.Guid().ToString(),
+                base64Image = faker.Random.Hash()
+            };
         }
     }
 }

--- a/mat-process-api.Tests/V1/Helper/MatProcessDataHelper.cs
+++ b/mat-process-api.Tests/V1/Helper/MatProcessDataHelper.cs
@@ -56,7 +56,7 @@ namespace mat_process_api.Tests.V1.Helper
             {
                 processRef = faker.Random.Guid().ToString(),
                 imageId = faker.Random.Guid().ToString(),
-                base64Image = faker.Random.Hash()
+                base64Image = "data:image/" + faker.System.FileExt() + ";base64," + Convert.ToBase64String(faker.Random.Bytes(512))
             };
         }
     }

--- a/mat-process-api.Tests/V1/Helper/ProcessImageDecoderTests.cs
+++ b/mat-process-api.Tests/V1/Helper/ProcessImageDecoderTests.cs
@@ -1,0 +1,70 @@
+using Bogus;
+using mat_process_api.V1.Domain;
+using mat_process_api.V1.Helpers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace mat_process_api.Tests.V1.Helper
+{
+    [TestFixture]
+    public class ProcessImageDecoderTests
+    {
+        private ProcessImageDecoder _processImageDecoder;
+        private Faker _faker = new Faker();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _processImageDecoder = new ProcessImageDecoder();
+        }
+
+        [Test]
+        public void given_a_base64ImageString_when_ProcessImageDecoder_is_called_then_it_returns_Base64DecodedData_with_correctly_decoded_byte_array() //in this case it's imageExtension
+        {
+            //arrange
+            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject().base64Image;
+            byte[] decodedImageBytes = Convert.FromBase64String(base64ImageString.Split(",")[1]); //expected decoded bytes
+
+            //act
+            var base64DecodedData = _processImageDecoder.DecodeBase64ImageString(base64ImageString);
+
+            //assert
+            Assert.NotNull(base64DecodedData);
+            Assert.IsInstanceOf<Base64DecodedData>(base64DecodedData);
+            Assert.True(decodedImageBytes.SequenceEqual(base64DecodedData.imageBytes));
+        }
+
+        [Test]
+        public void given_a_base64ImageString_when_ProcessImageDecoder_is_called_then_it_returns_Base64DecodedData_with_correctly_decoded_file_type() //in this case it's imageType
+        {
+            //arrange
+            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject().base64Image;
+            string decodedImageType = base64ImageString.Split(";")[0].Split(":")[1]; //expected File Type
+
+            //act
+            var base64DecodedData = _processImageDecoder.DecodeBase64ImageString(base64ImageString);
+
+            //assert
+            Assert.IsInstanceOf<Base64DecodedData>(base64DecodedData);
+            Assert.AreEqual(decodedImageType, base64DecodedData.imageType);
+        }
+
+        [Test]
+        public void given_a_base64ImageString_when_ProcessImageDecoder_is_called_then_it_returns_Base64DecodedData_with_correctly_decoded_file_extension() //in this case it's imageExtension
+        {
+            //arrange
+            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject().base64Image;
+            string decodedImageExtension = base64ImageString.Split(";")[0].Split(":")[1].Split("/")[1]; //expected File Type
+
+            //act
+            var base64DecodedData = _processImageDecoder.DecodeBase64ImageString(base64ImageString);
+
+            //assert
+            Assert.IsInstanceOf<Base64DecodedData>(base64DecodedData);
+            Assert.AreEqual(decodedImageExtension, base64DecodedData.imageExtension);
+        }
+    }
+}

--- a/mat-process-api.Tests/V1/UseCase/ProcessImageUseCaseTests.cs
+++ b/mat-process-api.Tests/V1/UseCase/ProcessImageUseCaseTests.cs
@@ -1,0 +1,87 @@
+using System;
+using mat_process_api.V1.Boundary;
+using mat_process_api.V1.UseCase;
+using NUnit.Framework;
+using Moq;
+using mat_process_api.V1.Gateways;
+using Bogus;
+using mat_process_api.V1.Domain;
+using System.Linq;
+using mat_process_api.V1.Helpers;
+
+namespace mat_process_api.Tests.V1.UseCase
+{
+    [TestFixture]
+    public class ProcessImageUseCaseTests
+    {
+        private IProcessImageUseCase _processImageUseCase;
+        private Mock<IProcessImageGateway> _mockGateway;
+        private Mock<IProcessImageDecoder> _mockImageDecoder;
+        private Faker _faker = new Faker();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockGateway = new Mock<IProcessImageGateway>();
+            _mockImageDecoder = new Mock<IProcessImageDecoder>();
+            _processImageUseCase = new ProcessImageUseCase(_mockGateway.Object, _mockImageDecoder.Object);
+        }
+
+        [Test]
+        public void when_ProcessImageUseCase_ExecutePost_method_is_called_then_it_calls_the_gateway()
+        {
+            //arrange
+            var request = new PostProcessImageRequest();
+
+            //act
+            _processImageUseCase.ExecutePost(request);
+
+            //assert
+            _mockGateway.Verify(g => g.PostProcessImage(It.IsAny<ProcessImageData>()), Times.Once);
+        }
+
+        [Test]
+        public void given_a_request_when_ProcessImageUseCase_ExecutePost_method_is_called_then_it_calls_the_ProcessImageDecoder_with_imageString_from_request()
+        {
+            //arrange
+            var request = new PostProcessImageRequest()
+            {
+                processRef = _faker.Random.Guid().ToString(),
+                imageId = _faker.Random.Guid().ToString(),
+                base64Image = _faker.Random.Hash()
+            };
+
+            //act
+            _processImageUseCase.ExecutePost(request);
+
+            //assert
+            _mockImageDecoder.Verify(d => d.DecodeBase64ImageString(It.Is<string>(s => s == request.base64Image)), Times.Once);
+        }
+
+        [Test]
+        public void given_a_request_object_when_ProcessImageUseCase_ExecutePost_method_is_called_then_it_calls_the_gateway_with_correct_data()
+        {
+            //arrange
+            var request = new PostProcessImageRequest()
+            {
+                processRef = _faker.Random.Guid().ToString(),
+                imageId = _faker.Random.Guid().ToString(),
+                base64Image = _faker.Random.Hash()
+            };
+
+            byte[] expectedImageBytes = Convert.FromBase64String(request.base64Image);
+
+            _mockImageDecoder.Setup(d => d.DecodeBase64ImageString(request.base64Image)).Returns(expectedImageBytes);
+
+            //act
+            _processImageUseCase.ExecutePost(request);
+
+            //assert
+            _mockGateway.Verify(g => g.PostProcessImage(It.Is<ProcessImageData>(obj =>
+                obj.processRef == request.processRef &&
+                obj.imageId == request.imageId &&
+                obj.imageBytes.SequenceEqual(expectedImageBytes)
+                )), Times.Once);
+        }
+    }
+}

--- a/mat-process-api.Tests/V1/UseCase/ProcessImageUseCaseTests.cs
+++ b/mat-process-api.Tests/V1/UseCase/ProcessImageUseCaseTests.cs
@@ -55,14 +55,13 @@ namespace mat_process_api.Tests.V1.UseCase
         }
 
         [Test]
-        public void given_a_request_object_when_ProcessImageUseCase_ExecutePost_method_is_called_then_it_calls_the_gateway_with_correct_data()
+        public void given_a_request_object_when_ProcessImageUseCase_ExecutePost_method_is_called_then_it_calls_the_gateway_with_correct_data() //test to see if usecase calls gateway with domain correctly built domain object
         {
             //arrange
             var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            var decodedData = MatProcessDataHelper.CreateBase64DecodedDataObject();
 
-            byte[] expectedImageBytes = Convert.FromBase64String(request.base64Image);
-
-            _mockImageDecoder.Setup(d => d.DecodeBase64ImageString(request.base64Image)).Returns(expectedImageBytes);
+            _mockImageDecoder.Setup(d => d.DecodeBase64ImageString(It.IsAny<string>())).Returns(decodedData); //At this step, this test does not care about the validity of the decoder output, it only cares to see if the usecase passes the decoder output into gateway or not.
 
             //act
             _processImageUseCase.ExecutePost(request);
@@ -71,7 +70,9 @@ namespace mat_process_api.Tests.V1.UseCase
             _mockGateway.Verify(g => g.PostProcessImage(It.Is<ProcessImageData>(obj =>
                 obj.processRef == request.processRef &&
                 obj.imageId == request.imageId &&
-                obj.imageBytes.SequenceEqual(expectedImageBytes)
+                obj.imageData.imageBytes.SequenceEqual(decodedData.imageBytes) &&
+                obj.imageData.imageType == decodedData.imageType &&
+                obj.imageData.imageExtension == decodedData.imageExtension
                 )), Times.Once);
         }
     }

--- a/mat-process-api.Tests/V1/UseCase/ProcessImageUseCaseTests.cs
+++ b/mat-process-api.Tests/V1/UseCase/ProcessImageUseCaseTests.cs
@@ -8,6 +8,7 @@ using Bogus;
 using mat_process_api.V1.Domain;
 using System.Linq;
 using mat_process_api.V1.Helpers;
+using mat_process_api.Tests.V1.Helper;
 
 namespace mat_process_api.Tests.V1.UseCase
 {
@@ -31,7 +32,7 @@ namespace mat_process_api.Tests.V1.UseCase
         public void when_ProcessImageUseCase_ExecutePost_method_is_called_then_it_calls_the_gateway()
         {
             //arrange
-            var request = new PostProcessImageRequest();
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
 
             //act
             _processImageUseCase.ExecutePost(request);
@@ -44,12 +45,7 @@ namespace mat_process_api.Tests.V1.UseCase
         public void given_a_request_when_ProcessImageUseCase_ExecutePost_method_is_called_then_it_calls_the_ProcessImageDecoder_with_imageString_from_request()
         {
             //arrange
-            var request = new PostProcessImageRequest()
-            {
-                processRef = _faker.Random.Guid().ToString(),
-                imageId = _faker.Random.Guid().ToString(),
-                base64Image = _faker.Random.Hash()
-            };
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
 
             //act
             _processImageUseCase.ExecutePost(request);
@@ -62,12 +58,7 @@ namespace mat_process_api.Tests.V1.UseCase
         public void given_a_request_object_when_ProcessImageUseCase_ExecutePost_method_is_called_then_it_calls_the_gateway_with_correct_data()
         {
             //arrange
-            var request = new PostProcessImageRequest()
-            {
-                processRef = _faker.Random.Guid().ToString(),
-                imageId = _faker.Random.Guid().ToString(),
-                base64Image = _faker.Random.Hash()
-            };
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
 
             byte[] expectedImageBytes = Convert.FromBase64String(request.base64Image);
 

--- a/mat-process-api.Tests/V1/Validators/PostProcessImageRequestValidatorTests.cs
+++ b/mat-process-api.Tests/V1/Validators/PostProcessImageRequestValidatorTests.cs
@@ -1,0 +1,145 @@
+using System;
+using mat_process_api.Tests.V1.Helper;
+using mat_process_api.V1.Boundary;
+using mat_process_api.V1.Validators;
+using NUnit.Framework;
+using FluentValidation.TestHelper;
+
+namespace mat_process_api.Tests.V1.Validators
+{
+    [TestFixture]
+    public class PostProcessImageRequestValidatorTests
+    {
+        private PostProcessImageRequestValidator _postValidator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _postValidator = new PostProcessImageRequestValidator();
+        }
+
+        #region field is required tests
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void given_a_request_with_null_empty_or_whitespace_processRef_when_postProcessImageRequestValidator_is_called_then_it_returns_an_error(string processRef)
+        {
+            //arrange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            request.processRef = processRef;
+
+            //act, assert
+            _postValidator.ShouldHaveValidationErrorFor(req => req.processRef, request).WithErrorMessage("Process reference must be provided.");
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void given_a_request_with_null_empty_or_whitespace_imageId_when_postProcessImageRequestValidator_is_called_then_it_returns_an_error(string imageId)
+        {
+            //arrange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            request.imageId = imageId;
+
+            //act, assert
+            _postValidator.ShouldHaveValidationErrorFor(req => req.imageId, request).WithErrorMessage("Image Id must be provided.");
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void given_a_request_with_null_empty_or_whitespace_base64Image_string_when_postProcessImageRequestValidator_is_called_then_it_returns_an_error(string base64Image)
+        {
+            //arrange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            request.base64Image = base64Image;
+
+            //act, assert
+            _postValidator.ShouldHaveValidationErrorFor(req => req.base64Image, request).WithErrorMessage("Base64 Image string must be provided.");
+        }
+
+        #endregion
+
+        #region format is invalid tests
+
+        [TestCase("fe7ce9fb-8833-e877-a28c-f0857e6962b")] //less characters than it should contain
+        [TestCase("6418aa75-f5ee6975-5279d2bcfee5f948")] //missing dashes
+        [TestCase("a98e23-4abd0-83542-4b83225-72b6adc65")] //dashes in the wrong places
+        [TestCase("ju5t50m3-w0rd-th4t-w1ll-m34nn0th1ng0")] //uses characters that are not among hexadecimal numerals
+        public void given_a_request_with_invalid_processRef_guid_when_postProcessImageRequestValidator_is_called_then_it_returns_an_error(string processRef)
+        {
+            //arrange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            request.processRef = processRef;
+
+            //act, assert
+            _postValidator.ShouldHaveValidationErrorFor(req => req.processRef, request).WithErrorMessage("You need to provide a valid process reference.");
+        }
+
+        [TestCase("fe7ce7fb-7733-e877-a28c-f0857e6962b")] //less characters than it should contain
+        [TestCase("6418aa75-f5ee6975-5279d7bcfee5f948")] //missing dashes
+        [TestCase("a98e73-4abd0-83542-4b73225-72b6adc65")] //dashes in the wrong places
+        [TestCase("ju5t70m3-w0rd-th4t-w1ll-m34nn0th1ng0")] //uses characters that are not among hexadecimal numerals
+        public void given_a_request_with_invalid_ImageId_guid_when_postProcessImageRequestValidator_is_called_then_it_returns_an_error(string imageId)
+        {
+            //arrange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            request.imageId = imageId;
+
+            //act, assert
+            _postValidator.ShouldHaveValidationErrorFor(req => req.imageId, request).WithErrorMessage("You need to provide a valid Image Id.");
+        }
+
+        [TestCase("data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABI/2wBDAAgG\\BgcGBQgHwcJCQg")] //base64 bit contains characters that don't belong in base64 string
+        [TestCase("data:image/jpeg;base64,KVHFLFAApUcUaAG4pYo4pUADFKnYUOPUsUWA3FLFGjRYDcUqNKi")] //the base 64 bit of string is not of length multiple of 4
+        [TestCase("BAQFAwMEAQEJAQIDAAQREiExBUETIlFhBjJxgRSRobEjQlLt")] //doesn't start with 'data:image/{fileext};base64,'
+        [TestCase("data:imade/jpeg;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //does start with the 'data:image/{fileext};base64,', but it has a typo
+        [TestCase("data:image/zz;base64,/1j/7TTQSkZJRgACAQEASBBI/2wBDAAgG\\BgcGBQgHwcJCQg")] //file extension in the data bit is less than 3 chars long 
+        public void given_a_request_with_an_invalid_base64Image_string_when_postProcessImageRequestValidator_is_called_then_it_returns_an_error(string base64Image)
+        {
+            //arrange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+            request.base64Image = base64Image;
+
+            //act, assert
+            _postValidator.ShouldHaveValidationErrorFor(req => req.base64Image, request).WithErrorMessage("You need to provide a valid Base64 Image string.");
+        }
+
+        #endregion
+
+        #region format is valid tests
+
+        [Test]
+        public void given_a_request_with_valid_processRef_guid_when_postProcessImageRequestValidator_is_called_then_it_returns_no_error()
+        {
+            //arange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+
+            //act, assert
+            _postValidator.ShouldNotHaveValidationErrorFor(req => req.processRef, request);
+        }
+
+        [Test]
+        public void given_a_request_with_valid_ImageId_guid_when_postProcessImageRequestValidator_is_called_then_it_returns_no_error()
+        {
+            //arange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+
+            //act, assert
+            _postValidator.ShouldNotHaveValidationErrorFor(req => req.imageId, request);
+        }
+
+        [Test]
+        public void given_a_request_with_valid_base64Image_string_when_postProcessImageRequestValidator_is_called_then_it_returns_no_error()
+        {
+            //arange
+            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
+
+            //act, assert
+            _postValidator.ShouldNotHaveValidationErrorFor(req => req.base64Image, request);
+        }
+
+        #endregion 
+    }
+}

--- a/mat-process-api/Startup.cs
+++ b/mat-process-api/Startup.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Mvc.Versioning;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using mat_process_api.V1.Validators;
+using mat_process_api.V1.Helpers;
 
 namespace mat_process_api
 {
@@ -50,6 +51,7 @@ namespace mat_process_api
             RegisterGateWays(services);
             RegisterUseCases(services);
             RegisterValidators(services);
+            RegisterHelpers(services);
         }
 
         private static void ConfigureApiVersioningAndSwagger(IServiceCollection services)
@@ -137,12 +139,19 @@ namespace mat_process_api
         private static void RegisterUseCases(IServiceCollection services)
         {
             services.AddSingleton<IProcessData, ProcessDataUseCase>();
+            services.AddSingleton<IProcessImageUseCase, ProcessImageUseCase>();
         }
 
         private static void RegisterValidators(IServiceCollection services)
         {
             services.AddSingleton<IPostInitialProcessDocumentRequestValidator, PostInitialProcessDocumentRequestValidator>();
             services.AddSingleton<IUpdateProcessDocumentRequestValidator, UpdateProcessDocumentRequestValidator>();
+            services.AddSingleton<IPostProcessImageRequestValidator, PostProcessImageRequestValidator>();
+        }
+
+        private static void RegisterHelpers(IServiceCollection services)
+        {
+            services.AddSingleton<IProcessImageDecoder, ProcessImageDecoder>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/mat-process-api/V1/Boundary/PostProcessImageRequest.cs
+++ b/mat-process-api/V1/Boundary/PostProcessImageRequest.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace mat_process_api.V1.Boundary
+{
+    public class PostProcessImageRequest
+    {
+        public string processRef { get; set; }
+        public string imageId { get; set; }
+        public string base64Image { get; set; }
+    }
+}

--- a/mat-process-api/V1/Controllers/ProcessImageController.cs
+++ b/mat-process-api/V1/Controllers/ProcessImageController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using mat_process_api.V1.Boundary;
 using mat_process_api.V1.UseCase;
+using mat_process_api.V1.Validators;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,10 +17,12 @@ namespace mat_process_api.V1.Controllers
     public class ProcessImageController : Controller
     {
         private IProcessImageUseCase _processImageUseCase;
+        private IPostProcessImageRequestValidator _postValidator;
 
-        public ProcessImageController(IProcessImageUseCase usecase)
+        public ProcessImageController(IProcessImageUseCase usecase, IPostProcessImageRequestValidator postValidator)
         {
             _processImageUseCase = usecase;
+            _postValidator = postValidator;
         }
 
         /// <summary>
@@ -31,8 +34,10 @@ namespace mat_process_api.V1.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult PostProcessImage([FromBody] PostProcessImageRequest imageData)
         {
-            _processImageUseCase.ExecutePost(imageData);
+            _postValidator.Validate(imageData);
 
+            _processImageUseCase.ExecutePost(imageData);
+            
             return NoContent();
         }
     }

--- a/mat-process-api/V1/Controllers/ProcessImageController.cs
+++ b/mat-process-api/V1/Controllers/ProcessImageController.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using mat_process_api.V1.Boundary;
+using mat_process_api.V1.UseCase;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace mat_process_api.V1.Controllers
+{
+    [ApiVersion("1.0")]
+    [Route("api/v1/processImageData")] //<----- do we change this? url undecided
+    [ApiController]
+    [Produces("application/json")]
+    public class ProcessImageController : Controller
+    {
+        private IProcessImageUseCase _processImageUseCase;
+
+        public ProcessImageController(IProcessImageUseCase usecase)
+        {
+            _processImageUseCase = usecase;
+        }
+
+        /// <summary>
+        /// TODO: Add description
+        /// </summary>
+        /// <param name="imageData"></param>
+        [HttpPost]
+        [Produces("application/json")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public IActionResult PostProcessImage([FromBody] PostProcessImageRequest imageData)
+        {
+            _processImageUseCase.ExecutePost(imageData);
+
+            return NoContent();
+        }
+    }
+}

--- a/mat-process-api/V1/Controllers/ProcessImageController.cs
+++ b/mat-process-api/V1/Controllers/ProcessImageController.cs
@@ -34,11 +34,16 @@ namespace mat_process_api.V1.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult PostProcessImage([FromBody] PostProcessImageRequest imageData)
         {
-            _postValidator.Validate(imageData);
+            var validationResult = _postValidator.Validate(imageData);
 
-            _processImageUseCase.ExecutePost(imageData);
-            
-            return NoContent();
+            if (validationResult.IsValid)
+            {
+                _processImageUseCase.ExecutePost(imageData);
+
+                return NoContent();
+            }
+
+            return BadRequest(validationResult.Errors);
         }
     }
 }

--- a/mat-process-api/V1/Domain/ProcessImageData.cs
+++ b/mat-process-api/V1/Domain/ProcessImageData.cs
@@ -1,0 +1,10 @@
+using System;
+namespace mat_process_api.V1.Domain
+{
+    public class ProcessImageData
+    {
+        public string processRef { get; set; }
+        public string imageId { get; set; }
+        public byte[] imageBytes { get; set; }
+    }
+}

--- a/mat-process-api/V1/Domain/ProcessImageData.cs
+++ b/mat-process-api/V1/Domain/ProcessImageData.cs
@@ -5,6 +5,15 @@ namespace mat_process_api.V1.Domain
     {
         public string processRef { get; set; }
         public string imageId { get; set; }
+
+        public Base64DecodedData imageData { get; set; }
+        
+    }
+
+    public class Base64DecodedData
+    {
         public byte[] imageBytes { get; set; }
+        public string imageType { get; set; }
+        public string imageExtension { get; set; }
     }
 }

--- a/mat-process-api/V1/Factories/ImageDataFactory.cs
+++ b/mat-process-api/V1/Factories/ImageDataFactory.cs
@@ -6,13 +6,13 @@ namespace mat_process_api.V1.Factories
 {
     public static class ImageDataFactory
     {
-        public static ProcessImageData CreateImageDataObject(PostProcessImageRequest request, byte[] imageBytes)
+        public static ProcessImageData CreateImageDataObject(PostProcessImageRequest request, Base64DecodedData decodedStringData)
         {
             return new ProcessImageData()
             {
                 processRef = request.processRef,
                 imageId = request.imageId,
-                imageBytes = imageBytes
+                imageData = decodedStringData
             };
         }
     }

--- a/mat-process-api/V1/Factories/ImageDataFactory.cs
+++ b/mat-process-api/V1/Factories/ImageDataFactory.cs
@@ -1,0 +1,19 @@
+using System;
+using mat_process_api.V1.Boundary;
+using mat_process_api.V1.Domain;
+
+namespace mat_process_api.V1.Factories
+{
+    public static class ImageDataFactory
+    {
+        public static ProcessImageData CreateImageDataObject(PostProcessImageRequest request, byte[] imageBytes)
+        {
+            return new ProcessImageData()
+            {
+                processRef = request.processRef,
+                imageId = request.imageId,
+                imageBytes = imageBytes
+            };
+        }
+    }
+}

--- a/mat-process-api/V1/Gateways/IProcessImageGateway.cs
+++ b/mat-process-api/V1/Gateways/IProcessImageGateway.cs
@@ -1,0 +1,11 @@
+using System;
+using mat_process_api.V1.Boundary;
+using mat_process_api.V1.Domain;
+
+namespace mat_process_api.V1.Gateways
+{
+    public interface IProcessImageGateway
+    {
+        void PostProcessImage(ProcessImageData request);
+    }
+}

--- a/mat-process-api/V1/Helpers/IProcessImageDecoder.cs
+++ b/mat-process-api/V1/Helpers/IProcessImageDecoder.cs
@@ -1,0 +1,8 @@
+using System;
+namespace mat_process_api.V1.Helpers
+{
+    public interface IProcessImageDecoder
+    {
+        byte[] DecodeBase64ImageString(string imageString);
+    }
+}

--- a/mat-process-api/V1/Helpers/IProcessImageDecoder.cs
+++ b/mat-process-api/V1/Helpers/IProcessImageDecoder.cs
@@ -1,8 +1,9 @@
+using mat_process_api.V1.Domain;
 using System;
 namespace mat_process_api.V1.Helpers
 {
     public interface IProcessImageDecoder
     {
-        byte[] DecodeBase64ImageString(string imageString);
+        Base64DecodedData DecodeBase64ImageString(string imageString);
     }
 }

--- a/mat-process-api/V1/Helpers/ProcessImageDecoder.cs
+++ b/mat-process-api/V1/Helpers/ProcessImageDecoder.cs
@@ -1,0 +1,27 @@
+using mat_process_api.V1.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace mat_process_api.V1.Helpers
+{
+    public class ProcessImageDecoder : IProcessImageDecoder
+    {
+        public Base64DecodedData DecodeBase64ImageString(string imageString)
+        {
+            string base64Part = imageString.Split(",")[1];
+            byte[] base64Bytes = Convert.FromBase64String(base64Part);
+            string fileTypePart = Regex.Match(imageString, @"(?<=:).+(?=;)").Value;
+            string fileExt = Regex.Match(fileTypePart, @"(?<=\/).+").Value;
+
+            return new Base64DecodedData()
+            {
+                imageBytes = base64Bytes,
+                imageType = fileTypePart,
+                imageExtension = fileExt
+            };
+        }
+    }
+}

--- a/mat-process-api/V1/UseCase/IProcessImageUseCase.cs
+++ b/mat-process-api/V1/UseCase/IProcessImageUseCase.cs
@@ -1,0 +1,13 @@
+using mat_process_api.V1.Boundary;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace mat_process_api.V1.UseCase
+{
+    public interface IProcessImageUseCase
+    {
+        void ExecutePost(PostProcessImageRequest request);
+    }
+}

--- a/mat-process-api/V1/UseCase/ProcessImageUseCase.cs
+++ b/mat-process-api/V1/UseCase/ProcessImageUseCase.cs
@@ -1,0 +1,29 @@
+using System;
+using mat_process_api.V1.Boundary;
+using mat_process_api.V1.Domain;
+using mat_process_api.V1.Factories;
+using mat_process_api.V1.Gateways;
+using mat_process_api.V1.Helpers;
+
+namespace mat_process_api.V1.UseCase
+{
+    public class ProcessImageUseCase : IProcessImageUseCase
+    {
+        private IProcessImageGateway _processImageGateway;
+        private IProcessImageDecoder _processImageDecoder;
+
+        public ProcessImageUseCase(IProcessImageGateway gateway, IProcessImageDecoder imageDecoder)
+        {
+            _processImageGateway = gateway;
+            _processImageDecoder = imageDecoder;
+        }
+
+        public void ExecutePost(PostProcessImageRequest request)
+        {
+            byte[] imageBytes = _processImageDecoder.DecodeBase64ImageString(request.base64Image);
+            ProcessImageData imageData = ImageDataFactory.CreateImageDataObject(request, imageBytes);
+
+            _processImageGateway.PostProcessImage(imageData);
+        }
+    }
+}

--- a/mat-process-api/V1/UseCase/ProcessImageUseCase.cs
+++ b/mat-process-api/V1/UseCase/ProcessImageUseCase.cs
@@ -20,8 +20,8 @@ namespace mat_process_api.V1.UseCase
 
         public void ExecutePost(PostProcessImageRequest request)
         {
-            byte[] imageBytes = _processImageDecoder.DecodeBase64ImageString(request.base64Image);
-            ProcessImageData imageData = ImageDataFactory.CreateImageDataObject(request, imageBytes);
+            Base64DecodedData base64Decoded = _processImageDecoder.DecodeBase64ImageString(request.base64Image);
+            ProcessImageData imageData = ImageDataFactory.CreateImageDataObject(request, base64Decoded);
 
             _processImageGateway.PostProcessImage(imageData);
         }

--- a/mat-process-api/V1/Validators/IPostProcessImageRequestValidator.cs
+++ b/mat-process-api/V1/Validators/IPostProcessImageRequestValidator.cs
@@ -1,0 +1,11 @@
+using System;
+using FluentValidation.Results;
+using mat_process_api.V1.Boundary;
+
+namespace mat_process_api.V1.Validators
+{
+    public interface IPostProcessImageRequestValidator
+    {
+        ValidationResult Validate(PostProcessImageRequest request);
+    }
+}

--- a/mat-process-api/V1/Validators/PostProcessImageRequestValidator.cs
+++ b/mat-process-api/V1/Validators/PostProcessImageRequestValidator.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Text.RegularExpressions;
+using FluentValidation;
+using mat_process_api.V1.Boundary;
+
+namespace mat_process_api.V1.Validators
+{
+    public class PostProcessImageRequestValidator : AbstractValidator<PostProcessImageRequest>, IPostProcessImageRequestValidator
+    {
+        public PostProcessImageRequestValidator()
+        {
+            ValidatorOptions.CascadeMode = CascadeMode.StopOnFirstFailure; // Stops the validator from going into DependentRules or deeper into any single rule in general. This is needed because it doesn't make sense to keep checking if property is empty, once it was determined it's null.
+
+            RuleFor(req => req.processRef).NotNull().WithMessage("Process reference must be provided.").NotEmpty().WithMessage("Process reference must be provided.").Must(ValidateGuid)
+               .WithMessage("You need to provide a valid process reference.");
+            RuleFor(req => req.imageId).NotNull().WithMessage("Image Id must be provided.").NotEmpty().WithMessage("Image Id must be provided.").Must(ValidateGuid)
+                .WithMessage("You need to provide a valid Image Id.");
+            RuleFor(req => req.base64Image).NotNull().WithMessage("Base64 Image string must be provided.").NotEmpty().WithMessage("Base64 Image string must be provided.")
+                .Must(ValidateBase64Length).WithMessage("You need to provide a valid Base64 Image string.")
+                .Matches(new Regex(@"^data:image\/([^_\W]{3,});base64,([^_\W]|[+\/])+={0,3}$")).WithMessage("You need to provide a valid Base64 Image string.");
+        }
+
+        private bool ValidateGuid(string guid)
+        {
+            return Guid.TryParse(guid, out var result);
+        }
+
+        private bool ValidateBase64Length(string imageBase64)
+        {
+            var stringParts = imageBase64.Split(",");
+            if (stringParts.Length != 2) { return false; }
+            var base64partLenght = stringParts[1].Length;
+            return 0 == base64partLenght % 4;
+        }
+    }
+}


### PR DESCRIPTION
# What:
- A Skeleton of the Post Process Image endpoint.
- Boundary object
- Domain object 
- Controller (calls the Validator, returns response accordingly)
- ImageDecoder (decodes the base64 string)
- UseCase (calls the decoder, factory and gateway)
- Validator (validates Boundary Request object)
- Factory (to transform between Boundary and Domain)
- Few Helper methods for the tests that generate the Boundary, Domain and domain Child objects.
- Everything is covered by tests.
- Services added to Dependency Injection

# Missing:
- Gateway (currently just the interface)
- Boundary does not have the Json tags above it's properties - they might be needed if the mapping from an actual request to Request Boundary doesn't happen.
- Error Handling in the controller.
- Endpoint Acceptance tests.

# Why:
- No boundary mapping since we don't know how the properties from the json object coming from the front end will look like.
- No error handling, it's sort of dependant on the Gateway, so can't add it yet.
- No acceptance tests, because of missing Gateway.
- No Gateway, because interaction with the Amazon S3 was a Spike parallel to this work.
- Domain object has child object, because it was decided that it would be cleaner to have decoded data all in one place to avoid too many factory or gateway parameters.