### PR TITLE
Fixed the GetProcessData endpoint 404 response, also added few other …

### DIFF
--- a/mat-process-api.Tests/V1/Gateways/ProcessesGatewayTests.cs
+++ b/mat-process-api.Tests/V1/Gateways/ProcessesGatewayTests.cs
@@ -36,6 +36,8 @@ namespace UnitTests.V1.Gateways
             processDataGateway = new ProcessDataGateway(mockContext.Object);
         }
 
+        #region Get Process Document
+
         [Test]
         public void test_that_gateway_class_implements_gateway_interface()
         {
@@ -68,29 +70,17 @@ namespace UnitTests.V1.Gateways
             Assert.IsInstanceOf<MatProcessData>(result);
         }
 
-
         [Test]
-        public void test_that_gateway_return_mat_process_object_if_no_match_is_found()
+        public void given_nonexistent_processRef_when_GetProcessData_gateway_method_is_called_then_gateway_throws_DocumentNotFound_exception()
         {
             //arrange
-            string id = _faker.Random.Guid().ToString();
-            //act
-            var result = processDataGateway.GetProcessData(id);
-            //assert
-            Assert.Null(result.Id);
-            Assert.Null(result.ProcessType);
-            Assert.AreEqual(DateTime.MinValue, result.DateCreated);
-            Assert.AreEqual(DateTime.MinValue, result.DateLastModified);
-            Assert.AreEqual(DateTime.MinValue, result.DateCompleted);
-            Assert.False(result.ProcessDataAvailable);
-            Assert.Zero(result.ProcessDataSchemaVersion);
-            Assert.Null(result.ProcessStage);
-            Assert.Null(result.LinkedProcessId);
-            Assert.Null(result.PreProcessData);
-            Assert.Null(result.ProcessData);
-            Assert.Null(result.PostProcessData);
-            Assert.IsInstanceOf<MatProcessData>(result);
+            string processRef = _faker.Random.Guid().ToString();
+
+            //act, assert
+            Assert.Throws<DocumentNotFound>(() => processDataGateway.GetProcessData(processRef));
         }
+
+        #endregion
 
         #region Update Process
         [Test]

--- a/mat-process-api/V1/Controllers/ProcessDataController.cs
+++ b/mat-process-api/V1/Controllers/ProcessDataController.cs
@@ -63,7 +63,7 @@ namespace mat_process_api.V1.Controllers
                 }
                 catch(DocumentNotFound ex)
                 {
-                    return StatusCode(404, ($"Document with reference {request.processRef} was not found in the database"));
+                    return NotFound($"Document with reference {request.processRef} was not found in the database");
                 }
                 catch(Exception ex)
                 {

--- a/mat-process-api/V1/Gateways/ProcessDataGateway.cs
+++ b/mat-process-api/V1/Gateways/ProcessDataGateway.cs
@@ -28,7 +28,12 @@ namespace mat_process_api.V1.Gateways
             var filter = Builders<BsonDocument>.Filter.Eq("_id", processRef);
             //we will never expect more than one JSON documents matching an ID so we always choose the first/default result
             var result = matDbContext.getCollection().FindAsync(filter).Result.FirstOrDefault();
-            
+            //if document does not exist in the DB, then thrown a corresponsing error.
+            if (result == null)
+            {
+                throw new DocumentNotFound();
+            }
+
             return ProcessDataFactory.CreateProcessDataObject(result);
         }
 


### PR DESCRIPTION
# What:
- Fixed Get Process Data endpoint document not found response.
- Added few other test to cover the endpoint acceptance for 200 and 400 responses.

# Why:
- Previously the endpoint was returning 200 'Ok' instead 404 'NotFound', when there was an attempt to retrieve a non-existent document.

# Notes:
- The 500 status code acceptance test could not be implemented due there being no clear way to raise an exception within the test.