### PR TITLE
Feature/disable validation for base64 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,10 +155,7 @@ jobs:
 workflows:
   check-and-deploy:
       jobs:
-      - build-and-test:
-          filters:
-            branches:
-              only: development
+      - build-and-test
       - build_and_push_image_development:
           context: mat-assume-role-context
           requires:

--- a/mat-process-api.Tests/V1/Validators/PostProcessImageRequestValidatorTests.cs
+++ b/mat-process-api.Tests/V1/Validators/PostProcessImageRequestValidatorTests.cs
@@ -91,21 +91,6 @@ namespace mat_process_api.Tests.V1.Validators
             _postValidator.ShouldHaveValidationErrorFor(req => req.imageId, request).WithErrorMessage("You need to provide a valid Image Id.");
         }
 
-        [TestCase("data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABI/2wBDAAgG\\BgcGBQgHwcJCQg")] //base64 bit contains characters that don't belong in base64 string
-        [TestCase("data:image/jpeg;base64,KVHFLFAApUcUaAG4pYo4pUADFKnYUOPUsUWA3FLFGjRYDcUqNKi")] //the base 64 bit of string is not of length multiple of 4
-        [TestCase("BAQFAwMEAQEJAQIDAAQREiExBUETIlFhBjJxgRSRobEjQlLt")] //doesn't start with 'data:image/{fileext};base64,'
-        [TestCase("data:imade/jpeg;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //does start with the 'data:image/{fileext};base64,', but it has a typo
-        [TestCase("data:image/zz;base64,/1j/7TTQSkZJRgACAQEASBBI/2wBDAAgG\\BgcGBQgHwcJCQg")] //file extension in the data bit is less than 3 chars long 
-        public void given_a_request_with_an_invalid_base64Image_string_when_postProcessImageRequestValidator_is_called_then_it_returns_an_error(string base64Image)
-        {
-            //arrange
-            var request = MatProcessDataHelper.CreatePostProcessImageRequestObject();
-            request.base64Image = base64Image;
-
-            //act, assert
-            _postValidator.ShouldHaveValidationErrorFor(req => req.base64Image, request).WithErrorMessage("You need to provide a valid Base64 Image string.");
-        }
-
         #endregion
 
         #region format is valid tests

--- a/mat-process-api/V1/Validators/PostProcessImageRequestValidator.cs
+++ b/mat-process-api/V1/Validators/PostProcessImageRequestValidator.cs
@@ -1,7 +1,6 @@
-using System;
-using System.Text.RegularExpressions;
 using FluentValidation;
 using mat_process_api.V1.Boundary;
+using System;
 
 namespace mat_process_api.V1.Validators
 {
@@ -15,22 +14,12 @@ namespace mat_process_api.V1.Validators
                .WithMessage("You need to provide a valid process reference.");
             RuleFor(req => req.imageId).NotNull().WithMessage("Image Id must be provided.").NotEmpty().WithMessage("Image Id must be provided.").Must(ValidateGuid)
                 .WithMessage("You need to provide a valid Image Id.");
-            RuleFor(req => req.base64Image).NotNull().WithMessage("Base64 Image string must be provided.").NotEmpty().WithMessage("Base64 Image string must be provided.")
-                .Must(ValidateBase64Length).WithMessage("You need to provide a valid Base64 Image string.")
-                .Matches(new Regex(@"^data:image\/([^_\W]{3,});base64,([^_\W]|[+\/])+={0,3}$")).WithMessage("You need to provide a valid Base64 Image string.");
+            RuleFor(req => req.base64Image).NotNull().WithMessage("Base64 Image string must be provided.").NotEmpty().WithMessage("Base64 Image string must be provided.");
         }
 
         private bool ValidateGuid(string guid)
         {
             return Guid.TryParse(guid, out var result);
-        }
-
-        private bool ValidateBase64Length(string imageBase64)
-        {
-            var stringParts = imageBase64.Split(",");
-            if (stringParts.Length != 2) { return false; }
-            var base64partLenght = stringParts[1].Length;
-            return 0 == base64partLenght % 4;
         }
     }
 }


### PR DESCRIPTION
#what
1. Remove validation for base64 string property when posting images
2. Remove branch filter from CircleCi build-and-test job so it runs against all dev branches

#Why
Current validation implementation against large base64 strings is too heavy and takes up too much resources. In many cases it ends up killing the container when handling concurrent calls

