### PR TITLE
Feature/improve error handling for image uploads

### DIFF
--- a/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
+++ b/mat-process-api.Tests/V1/Controllers/ProcessDataImagesControllerTests.cs
@@ -164,7 +164,7 @@ namespace mat_process_api.Tests.V1.Controllers
         }
 
         [Test]
-        public void given_an_exception_thrown_check_that_the_controller_throws_correct_exception_and_500_status_code()
+        public void given_ImageNotInsertedToS3_exception_thrown_check_that_the_controller_throws_correct_exception_and_500_status_code()
         {
             var expectedStatusCode = 500;
             var request = new PostProcessImageRequest(); //an empty request will be invalid
@@ -181,6 +181,66 @@ namespace mat_process_api.Tests.V1.Controllers
             Assert.NotNull(result);
             Assert.AreEqual(expectedStatusCode, result.StatusCode);
         }
+
+        [Test]
+        public void given_ProcessImageDecoderException_exception_thrown_check_that_the_controller_throws_correct_exception_and_400_status_code()
+        {
+            var expectedStatusCode = 400;
+            var request = new PostProcessImageRequest(); //an empty request will be invalid
+
+            var fakeValidationResult = new FV.ValidationResult(); 
+            _mockPostValidator.Setup(v => v.Validate(It.IsAny<PostProcessImageRequest>())).Returns(fakeValidationResult);
+            _mockUsecase.Setup(x => x.ExecutePost(request)).Throws<ProcessImageDecoderException>();
+            //act
+            var controllerResponse = _processImageController.PostProcessImage(request);
+            var result = controllerResponse as ObjectResult;
+
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(result);
+            Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+
+        [Test]
+        public void given_Base64StringConversionToByteArrayException_exception_thrown_check_that_the_controller_throws_correct_exception_and_400_status_code()
+        {
+            var expectedStatusCode = 400;
+            var request = new PostProcessImageRequest(); //an empty request will be invalid
+
+            var fakeValidationResult = new FV.ValidationResult();
+            _mockPostValidator.Setup(v => v.Validate(It.IsAny<PostProcessImageRequest>())).Returns(fakeValidationResult);
+            _mockUsecase.Setup(x => x.ExecutePost(request)).Throws<Base64StringConversionToByteArrayException>();
+
+            //act
+            var controllerResponse = _processImageController.PostProcessImage(request);
+            var result = controllerResponse as ObjectResult;
+
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(result);
+            Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+
+        [Test]
+        public void given_other_Exception_thrown_check_that_the_controller_throws_correct_exception_and_500_status_code()
+        {
+            var expectedStatusCode = 500;
+            var request = new PostProcessImageRequest(); //an empty request will be invalid
+            var randomExpectedException = ErrorThrowerHelper.GenerateError();
+
+            var fakeValidationResult = new FV.ValidationResult();
+            _mockPostValidator.Setup(v => v.Validate(It.IsAny<PostProcessImageRequest>())).Returns(fakeValidationResult);
+            _mockUsecase.Setup(x => x.ExecutePost(request)).Throws(randomExpectedException);
+            //act
+            var controllerResponse = _processImageController.PostProcessImage(request);
+            var result = controllerResponse as ObjectResult;
+
+            //assert
+            Assert.NotNull(controllerResponse);
+            Assert.NotNull(result);
+            Assert.AreEqual(expectedStatusCode, result.StatusCode);
+        }
+
         #endregion
 
         #region Get Process Image

--- a/mat-process-api.Tests/V1/Helper/MatProcessDataHelper.cs
+++ b/mat-process-api.Tests/V1/Helper/MatProcessDataHelper.cs
@@ -73,6 +73,17 @@ namespace mat_process_api.Tests.V1.Helper
             };
         }
 
+        public static PostProcessImageRequest CreatePostProcessImageRequestObject(string fileExtension)
+        {
+            return new PostProcessImageRequest()
+            {
+                processRef = faker.Random.Guid().ToString(),
+                imageId = faker.Random.Guid().ToString(),
+                base64Image = "data:image/" + fileExtension + ";base64," + Convert.ToBase64String(faker.Random.Bytes(512)),
+                processType = faker.Random.Word()
+            };
+        }
+
         public static Base64DecodedData CreateBase64DecodedDataObject()
         {
             var fileExt = faker.System.FileExt();

--- a/mat-process-api.Tests/V1/Helper/ProcessImageDecoderTests.cs
+++ b/mat-process-api.Tests/V1/Helper/ProcessImageDecoderTests.cs
@@ -81,6 +81,19 @@ namespace mat_process_api.Tests.V1.Helper
                             delegate { _processImageDecoder.DecodeBase64ImageString(base64String); }
                          );
         }
+
+        [TestCase("data:image/jpeg;base64,")] //missing base64 content after comma
+        public void given_missing_base64_content_is_passed_in_base64ImageString_when_ProcessImageDecoder_is_called_then_decoder_throws_ProcessImageDecoderException_with_correct_message(string base64String)
+        {
+            //arrange
+            string expectedMessage = "Missing base64 content";
+
+            //assert
+            Assert.Throws(Is.TypeOf<ProcessImageDecoderException>().And.Message.EqualTo(expectedMessage),
+                            delegate { _processImageDecoder.DecodeBase64ImageString(base64String); }
+                         );
+        }
+
         //check that base64 string is ready for convertion to byte array. Checking the validity of the entire string is too heavy at this level so has to be done on infrastructure level
         [TestCase("data:image/jpeg;base64B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //missing comma after base64
         public void given_comma_is_missing_from_base64String_when_ProcessImageDecoder_is_called_then_decoder_throws_ProcessImageDecoderException_with_correct_message(string base64String)

--- a/mat-process-api.Tests/V1/Helper/ProcessImageDecoderTests.cs
+++ b/mat-process-api.Tests/V1/Helper/ProcessImageDecoderTests.cs
@@ -1,5 +1,6 @@
 using Bogus;
 using mat_process_api.V1.Domain;
+using mat_process_api.V1.Exceptions;
 using mat_process_api.V1.Helpers;
 using NUnit.Framework;
 using System;
@@ -25,7 +26,7 @@ namespace mat_process_api.Tests.V1.Helper
         public void given_a_base64ImageString_when_ProcessImageDecoder_is_called_then_it_returns_Base64DecodedData_with_correctly_decoded_byte_array() //in this case it's imageExtension
         {
             //arrange
-            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject().base64Image;
+            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject("jpeg").base64Image;
             var decodedImageBytes = base64ImageString.Split(",")[1]; //expected decoded bytes
 
             //act
@@ -40,7 +41,7 @@ namespace mat_process_api.Tests.V1.Helper
         public void given_a_base64ImageString_when_ProcessImageDecoder_is_called_then_it_returns_Base64DecodedData_with_correctly_decoded_file_type() //in this case it's imageType
         {
             //arrange
-            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject().base64Image;
+            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject("jpeg").base64Image;
             string decodedImageType = base64ImageString.Split(";")[0].Split(":")[1]; //expected File Type
 
             //act
@@ -55,7 +56,7 @@ namespace mat_process_api.Tests.V1.Helper
         public void given_a_base64ImageString_when_ProcessImageDecoder_is_called_then_it_returns_Base64DecodedData_with_correctly_decoded_file_extension() //in this case it's imageExtension
         {
             //arrange
-            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject().base64Image;
+            string base64ImageString = MatProcessDataHelper.CreatePostProcessImageRequestObject("jpeg").base64Image;
             string decodedImageExtension = base64ImageString.Split(";")[0].Split(":")[1].Split("/")[1]; //expected File Type
 
             //act
@@ -64,6 +65,33 @@ namespace mat_process_api.Tests.V1.Helper
             //assert
             Assert.IsInstanceOf<Base64DecodedData>(base64DecodedData);
             Assert.AreEqual(decodedImageExtension, base64DecodedData.imageExtension);
+        }
+
+        //boundary object validation for base64 string property has been removed to improve performance
+        //gateway will handle some validation errors using exceptions, but these are required to cover the ones not caught by the gateway
+        [TestCase("data:imade/jpeg;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //does start with the 'data:image/{fileext};base64,', but it has a typo
+        [TestCase("data:image/zz;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //file extension in the data bit is not valid
+        [TestCase("data:image/jpeg;base64B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //missing comma after base64
+        public void given_invalid_filetype_is_passed_in_base64ImageString_when_ProcessImageDecoder_is_called_then_decoder_throws_ProcessImageDecoderException(string base64String)
+        {
+            //arrange
+            var expectedException = new ProcessImageDecoderException();
+            
+            //assert
+            Assert.Throws<ProcessImageDecoderException>(() => _processImageDecoder.DecodeBase64ImageString(base64String));
+        }
+
+        [TestCase("data:image/jpeg;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //jpeg
+        [TestCase("data:image/png;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //png
+        [TestCase("data:image/bmp;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //bmp
+        [TestCase("data:image/gif;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //gif
+        public void given_valid_filetype_is_passed_in_base64ImageString_when_ProcessImageDecoder_is_called_then_decoder_does_not_throw_an_error(string base64String)
+        {
+            //act
+            var result = _processImageDecoder.DecodeBase64ImageString(base64String);
+
+            //assert
+            Assert.IsInstanceOf<Base64DecodedData>(result);
         }
     }
 }

--- a/mat-process-api.Tests/V1/Helper/ProcessImageDecoderTests.cs
+++ b/mat-process-api.Tests/V1/Helper/ProcessImageDecoderTests.cs
@@ -71,21 +71,34 @@ namespace mat_process_api.Tests.V1.Helper
         //gateway will handle some validation errors using exceptions, but these are required to cover the ones not caught by the gateway
         [TestCase("data:imade/jpeg;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //does start with the 'data:image/{fileext};base64,', but it has a typo
         [TestCase("data:image/zz;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //file extension in the data bit is not valid
-        [TestCase("data:image/jpeg;base64B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //missing comma after base64
-        public void given_invalid_filetype_is_passed_in_base64ImageString_when_ProcessImageDecoder_is_called_then_decoder_throws_ProcessImageDecoderException(string base64String)
+        public void given_invalid_imageType_is_passed_in_base64ImageString_when_ProcessImageDecoder_is_called_then_decoder_throws_ProcessImageDecoderException_with_correct_message(string base64String)
         {
             //arrange
-            var expectedException = new ProcessImageDecoderException();
-            
+            string expectedMessage = "Invalid image type";
+
             //assert
-            Assert.Throws<ProcessImageDecoderException>(() => _processImageDecoder.DecodeBase64ImageString(base64String));
+            Assert.Throws(Is.TypeOf<ProcessImageDecoderException>().And.Message.EqualTo(expectedMessage),
+                            delegate { _processImageDecoder.DecodeBase64ImageString(base64String); }
+                         );
+        }
+        //check that base64 string is ready for convertion to byte array. Checking the validity of the entire string is too heavy at this level so has to be done on infrastructure level
+        [TestCase("data:image/jpeg;base64B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //missing comma after base64
+        public void given_comma_is_missing_from_base64String_when_ProcessImageDecoder_is_called_then_decoder_throws_ProcessImageDecoderException_with_correct_message(string base64String)
+        {
+            //arrange
+            string expectedMessage = "Unable to parse base64 string";
+
+            //assert
+            Assert.Throws(Is.TypeOf<ProcessImageDecoderException>().And.Message.EqualTo(expectedMessage),
+                                delegate { _processImageDecoder.DecodeBase64ImageString(base64String); }
+                            );
         }
 
         [TestCase("data:image/jpeg;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //jpeg
         [TestCase("data:image/png;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //png
         [TestCase("data:image/bmp;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //bmp
         [TestCase("data:image/gif;base64,B0RXh8DNi8QcWJHJDgjRTkiVEc4Oisv/EABoBAAMBAQEBAAA")] //gif
-        public void given_valid_filetype_is_passed_in_base64ImageString_when_ProcessImageDecoder_is_called_then_decoder_does_not_throw_an_error(string base64String)
+        public void given_valid_filetype_and_base64String_is_passed_in_base64ImageString_when_ProcessImageDecoder_is_called_then_decoder_does_not_throw_an_error(string base64String)
         {
             //act
             var result = _processImageDecoder.DecodeBase64ImageString(base64String);

--- a/mat-process-api/V1/Controllers/ProcessImageController.cs
+++ b/mat-process-api/V1/Controllers/ProcessImageController.cs
@@ -56,12 +56,12 @@ namespace mat_process_api.V1.Controllers
             //thrown if base64 string cannot be converted to valid Base64DecodedData object (validation cannot be done on boundary object at the moment for performance reasons)
             catch (ProcessImageDecoderException ex)
             {
-                return StatusCode(StatusCodes.Status400BadRequest, ex); //issue with base64 string input
+                return BadRequest(ex.Message); 
             }
-            //thrown if base64 string cannot be converter to byte array
+            //thrown if base64 string cannot be converted to byte array
             catch(Base64StringConversionToByteArrayException ex)
             {
-                return StatusCode(StatusCodes.Status400BadRequest, ex); //issue with base64 string input
+                return BadRequest(ex.Message); 
             }
             //thrown if uploading image to S3 fails
             catch (ImageNotInsertedToS3 ex)

--- a/mat-process-api/V1/Controllers/ProcessImageController.cs
+++ b/mat-process-api/V1/Controllers/ProcessImageController.cs
@@ -53,7 +53,23 @@ namespace mat_process_api.V1.Controllers
 
                 return BadRequest(validationResult.Errors);
             }
-            catch(ImageNotInsertedToS3 ex)
+            //thrown if base64 string cannot be converted to valid Base64DecodedData object (validation cannot be done on boundary object at the moment for performance reasons)
+            catch (ProcessImageDecoderException ex)
+            {
+                return StatusCode(StatusCodes.Status400BadRequest, ex); //issue with base64 string input
+            }
+            //thrown if base64 string cannot be converter to byte array
+            catch(Base64StringConversionToByteArrayException ex)
+            {
+                return StatusCode(StatusCodes.Status400BadRequest, ex); //issue with base64 string input
+            }
+            //thrown if uploading image to S3 fails
+            catch (ImageNotInsertedToS3 ex)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, ex);
+            }
+            //thrown for any other exception
+            catch(Exception ex)
             {
                 return StatusCode(StatusCodes.Status500InternalServerError, ex);
             }

--- a/mat-process-api/V1/Exceptions/CustomExceptions.cs
+++ b/mat-process-api/V1/Exceptions/CustomExceptions.cs
@@ -13,6 +13,15 @@ namespace mat_process_api.V1.Exceptions
     public class DocumentNotFound : Exception { }
     public class ImageNotInsertedToS3 : Exception { }
     public class ImageNotFound : Exception { }
-    public class ProcessImageDecoderException : Exception {}
+    public class ProcessImageDecoderException : Exception
+    {
+        public ProcessImageDecoderException() : base()
+        {
+        }
+        public ProcessImageDecoderException(string message) : base(message)
+        {
+        }
+    }
     public class Base64StringConversionToByteArrayException : Exception { }
+
 }

--- a/mat-process-api/V1/Exceptions/CustomExceptions.cs
+++ b/mat-process-api/V1/Exceptions/CustomExceptions.cs
@@ -5,12 +5,14 @@ using System.Threading.Tasks;
 
 namespace mat_process_api.V1.Exceptions
 {
-     public class ConflictException : System.Exception
+    public class ConflictException : System.Exception
     {
-    public ConflictException(String message, Exception inner) : base(message, inner) { }
+        public ConflictException(String message, Exception inner) : base(message, inner) { }
     }
 
     public class DocumentNotFound : Exception { }
     public class ImageNotInsertedToS3 : Exception { }
     public class ImageNotFound : Exception { }
+    public class ProcessImageDecoderException : Exception {}
+    public class Base64StringConversionToByteArrayException : Exception { }
 }

--- a/mat-process-api/V1/Gateways/ImagePersistingGateway.cs
+++ b/mat-process-api/V1/Gateways/ImagePersistingGateway.cs
@@ -23,20 +23,14 @@ namespace mat_process_api.V1.Gateways
         }
 
         public void UploadImage(ProcessImageData request)
-        {
-            try
+        {   
+            //insert image
+            var result = s3Client.insertImage(assumeRoleHelper.GetTemporaryCredentials(), request.imageData.imagebase64String.ToString(), request.key,
+                request.imageData.imageType);
+
+            if (result.HttpStatusCode != HttpStatusCode.OK)
             {
-                //insert image
-                var result = s3Client.insertImage(assumeRoleHelper.GetTemporaryCredentials(), request.imageData.imagebase64String.ToString(), request.key,
-                    request.imageData.imageType);
-                if (result.HttpStatusCode != HttpStatusCode.OK)
-                {
-                    throw new ImageNotInsertedToS3();
-                }
-            }
-            catch(Exception ex)
-            {
-                throw new ImageNotInsertedToS3(); //500
+                throw new ImageNotInsertedToS3();
             }
         }
 

--- a/mat-process-api/V1/Helpers/ProcessImageDecoder.cs
+++ b/mat-process-api/V1/Helpers/ProcessImageDecoder.cs
@@ -20,19 +20,22 @@ namespace mat_process_api.V1.Helpers
                 string fileExt = Regex.Match(fileTypePart, @"(?<=\/).+").Value;
 
                 //do additional validation here since it's too heavy to run against the boundary object
-                if (allowedFileTypes.Contains(fileTypePart))
+
+                if (string.IsNullOrWhiteSpace(base64Part))
                 {
-                    return new Base64DecodedData()
-                    {
-                        imagebase64String = base64Part,
-                        imageType = fileTypePart,
-                        imageExtension = fileExt
-                    };
+                    throw new ProcessImageDecoderException("Missing base64 content");
                 }
-                else
+                if (!allowedFileTypes.Contains(fileTypePart))
                 {
                     throw new ProcessImageDecoderException("Invalid image type");
                 }
+
+                return new Base64DecodedData()
+                {
+                    imagebase64String = base64Part,
+                    imageType = fileTypePart,
+                    imageExtension = fileExt
+                };
             }
             catch (Exception ex)
             {

--- a/mat-process-api/V1/Helpers/ProcessImageDecoder.cs
+++ b/mat-process-api/V1/Helpers/ProcessImageDecoder.cs
@@ -1,27 +1,44 @@
 using mat_process_api.V1.Domain;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+using mat_process_api.V1.Exceptions;
 
 namespace mat_process_api.V1.Helpers
 {
     public class ProcessImageDecoder : IProcessImageDecoder
     {
+        //TODO: move to config
+        //check for valid image/ part as well
+        private static readonly List<string> allowedFileTypes = new List<string>() { "image/jpeg", "image/png", "image/bmp", "image/gif" };
+
         public Base64DecodedData DecodeBase64ImageString(string imageString)
         {
-            string base64Part = imageString.Split(",")[1];
-            //byte[] base64Bytes = Convert.FromBase64String(base64Part);
-            string fileTypePart = Regex.Match(imageString, @"(?<=:).+(?=;)").Value;
-            string fileExt = Regex.Match(fileTypePart, @"(?<=\/).+").Value;
-
-            return new Base64DecodedData()
+            try
             {
-                imagebase64String = base64Part,
-                imageType = fileTypePart,
-                imageExtension = fileExt
-            };
+                string base64Part = imageString.Split(",")[1];
+                string fileTypePart = Regex.Match(imageString, @"(?<=:).+(?=;)").Value;
+                string fileExt = Regex.Match(fileTypePart, @"(?<=\/).+").Value;
+
+                //do additional validation here since it's too heavy to run against the boundary object
+                if (allowedFileTypes.Contains(fileTypePart))
+                {
+                    return new Base64DecodedData()
+                    {
+                        imagebase64String = base64Part,
+                        imageType = fileTypePart,
+                        imageExtension = fileExt
+                    };
+                }
+                else
+                {
+                    throw new ProcessImageDecoderException();
+                }
+            }
+            catch (Exception)
+            {
+                throw new ProcessImageDecoderException();
+            }
         }
     }
 }

--- a/mat-process-api/V1/Helpers/ProcessImageDecoder.cs
+++ b/mat-process-api/V1/Helpers/ProcessImageDecoder.cs
@@ -8,8 +8,7 @@ namespace mat_process_api.V1.Helpers
 {
     public class ProcessImageDecoder : IProcessImageDecoder
     {
-        //TODO: move to config
-        //check for valid image/ part as well
+        //check for valid 'image/' part as well
         private static readonly List<string> allowedFileTypes = new List<string>() { "image/jpeg", "image/png", "image/bmp", "image/gif" };
 
         public Base64DecodedData DecodeBase64ImageString(string imageString)
@@ -32,12 +31,12 @@ namespace mat_process_api.V1.Helpers
                 }
                 else
                 {
-                    throw new ProcessImageDecoderException();
+                    throw new ProcessImageDecoderException("Invalid image type");
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                throw new ProcessImageDecoderException();
+                throw ex is ProcessImageDecoderException ? ex : new ProcessImageDecoderException("Unable to parse base64 string");
             }
         }
     }

--- a/mat-process-api/V1/Infrastructure/AwsS3Client.cs
+++ b/mat-process-api/V1/Infrastructure/AwsS3Client.cs
@@ -7,20 +7,28 @@ using System.Threading.Tasks;
 using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
+using mat_process_api.V1.Exceptions;
 
 namespace mat_process_api.V1.Infrastructure
 {
     public class AwsS3Client : IAmazonS3Client
     {
-      
-        public PutObjectResponse insertImage(AWSCredentials credentials, string base64, string key,string contentType)
+        public PutObjectResponse insertImage(AWSCredentials credentials, string base64, string key, string contentType)
         {
-          
+            byte[] data;
+            var s3Client = new AmazonS3Client(credentials, Amazon.RegionEndpoint.EUWest2);
+
             try
             {
-                var s3Client = new AmazonS3Client(credentials, Amazon.RegionEndpoint.EUWest2);
-            
-                byte[] data = Convert.FromBase64String(base64);
+                data = Convert.FromBase64String(base64);
+            }
+            catch (Exception) //ArgumentNull or Format exception
+            {
+                throw new Base64StringConversionToByteArrayException();
+            }
+
+            try
+            {
                 using (var stream = new MemoryStream(data))
                 {
                     var putRequest1 = new PutObjectRequest
@@ -34,9 +42,9 @@ namespace mat_process_api.V1.Infrastructure
                     return response;
                 }
             }
-            catch(Exception ex)
-            {
-                throw ex;
+            catch (Exception)
+            {   
+                throw new ImageNotInsertedToS3();
             }     
         }
 


### PR DESCRIPTION
**What**
Improve error handling to address comments about further testing in PR #33 

**Why**
Because doing base64 string validation on boundary object turned out to be too heavy, we have to do the validation differently to ensure we don't let invalid data through. We also need to ensure that client gets detailed error messages

**How**

1. I've added custom exceptions that get thrown at appropriate places. We can validate the basic  structure of the string in _ProcessImageDecoder_ without having to parse the entire base64 content. Any issues detected with the structure are returned to the controller by throwing _ProcessImageDecoderException_ with appropriate message
2. Validating the base64 content itself is the expensive part, but because we need to convert it to byte array, we get a validation of sorts for free since converting invalid string will throw an exception. Instead of using the generic ImageNotInsertedToS3 exception, I have added a new one, _Base64StringConversionToByteArrayException_ so it's easier to identify the point of failure when troubleshooting issues
3. At controller level _ProcessImageDecoderException_ and _Base64StringConversionToByteArrayException_ are handled as related to bad requests so status code is set accordingly